### PR TITLE
Add Steering Committee 23 Oct 2024 meeting notes

### DIFF
--- a/steering-committee/2024-10-23-UXL-Steering-Committee.rst
+++ b/steering-committee/2024-10-23-UXL-Steering-Committee.rst
@@ -13,12 +13,12 @@ Attendees
 
 Notes:
 
-Rod provided he following updates:
+Rod provided the following updates:
 
 * The UXL Foundation Member Meeting is scheduled on Wednesday December 4th. The event will provide an opportunity for a retrospective, as well as presentation of the budget and goals for 2025. It will likely coincide with the annual report publication. A Save the Date will be sent to the UXL Foundation membership next month.
 * The oneAPI Construction Kit project has moved to the UXL GitHhub.
-* All DevSummit presentation recordings are now available ononeapi.io
-* The UXL Foundation is hosting a breakfast event at SC’24 with short presentations and a social afterwards. If you are planning to be at SC'24, make sure to register.
+* All DevSummit presentation recordings are now available on oneapi.io
+* The UXL Foundation is hosting a breakfast event at SC’24 with short presentations and a social afterwards. If you are planning to be at SC'24, make sure to register. https://linuxfoundation.regfox.com/uxl-foundation-at-sc-24
 
 DevSummits review and retrospective
 
@@ -31,3 +31,4 @@ DevSummits review and retrospective
 * Over 400 logged in to sessions live - one of the highest attendance rates for the previous DevSummits.
 * The NPS score is 73% (very good).
 * Rod thanked all who participated and expressed appreciation for the SC's attendance and engagement.
+* The feedback from the committee was noted and a set of actions for future events will be shared

--- a/steering-committee/2024-10-23-UXL-Steering-Committee.rst
+++ b/steering-committee/2024-10-23-UXL-Steering-Committee.rst
@@ -1,0 +1,33 @@
+=========================================================
+UXL Foundation Steering Committee Meeting 23 October 2024
+=========================================================
+
+Attendees
+
+* Rod Burns, Chair (Codeplay)
+* Megan Knight (Arm Limited)
+* Penporn Koanantakool (Google)
+* Dave Murray (Imagination) 
+* Andrew Wafaa (Arm Limited)
+* Melissa Aranzamendez, PM (Linux Foundation)
+
+Notes:
+
+Rod provided he following updates:
+
+* The UXL Foundation Member Meeting is scheduled on Wednesday December 4th. The event will provide an opportunity for a retrospective, as well as presentation of the budget and goals for 2025. It will likely coincide with the annual report publication. A Save the Date will be sent to the UXL Foundation membership next month.
+* The oneAPI Construction Kit project has moved to the UXL GitHhub.
+* All DevSummit presentation recordings are now available ononeapi.io
+* The UXL Foundation is hosting a breakfast event at SC’24 with short presentations and a social afterwards. If you are planning to be at SC'24, make sure to register.
+
+DevSummits review and retrospective
+
+* The SC provided feedback on their DevSummit experience and reviewed the event stats.
+* There were lots of good presentations:
+  * 30 accepted speakers from 22 unique organizations.
+  * 22 accepted sessions out of 33 submissions.
+  * 4 keynotes, 11 presentations, 5 lightning talks, 2 panels.
+  * 139 presentations downloaded, 44 questions asked.
+* Over 400 logged in to sessions live - one of the highest attendance rates for the previous DevSummits.
+* The NPS score is 73% (very good).
+* Rod thanked all who participated and expressed appreciation for the SC's attendance and engagement.

--- a/steering-committee/README.rst
+++ b/steering-committee/README.rst
@@ -10,6 +10,8 @@ outputs from the Working Groups.
 
 Minutes from the Steering Committee meetings are made available in this folder.
 
+`23rd October 2024 <2024-10-23-UXL-Steering-Committee.rst>`_
+
 `3rd October 2024 <2024-10-03-UXL-Steering-Committee.rst>`_
 
 `19th September 2024 <2024-09-05-UXL-Steering-Committee.rst>`_


### PR DESCRIPTION
The meeting was mostly spent discussing feedback and results from the oneAPI DevSummits hosted by the UXL Foundation.