### PR TITLE
Update date for Math SIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ The public calendar of UXL Foundation meetings is available using
 | 4 Feb 2025, 10am-11am US Central Time | Language SIG | Virtual |
 | 20 Feb 2025, 10am-11am US Central Time | Hardware SIG | Virtual |
 | 25 Feb 2025, 10am-11am US Central Time | Open Source Working Group | Virtual |
-| 26 Feb 2025, 10am-11am US Central Time | Math SIG | Virtual |
 | 6 Mar 2025, 10am-11am US Central Time | AI SIG | Virtual |
 | 12 Mar 2025, 10am-11am US Central Time | Marketing Committee | Virtual |
+| 28 May 2025, 9am-10am US Central Time | Math SIG | Virtual |
 
 [Join the relevant mailing list to receive an invite for the Working Groups and SIGs](https://lists.uxlfoundation.org/g/main)
 


### PR DESCRIPTION
Note also that the Math SIG is held at 9am Central time - this is an hour earlier than most other meetings